### PR TITLE
Fixes uninstall function and updates readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ An electron devtools extension for debugging Vue.js applications.
 
 ## Usage
 
+### Installing
 In an electron proj
 
 ```bash
@@ -24,6 +25,23 @@ app.on('ready', () => {
   ....
 })
 ```
+
+### Uninstalling
+
+Running uniinstall in your `main.js`
+
+```javascript
+const { app, BrowserWindow } = require('electron')
+app.on('ready', () => {
+  ....
+  if (process.env.NODE_ENV !== 'production') {
+    require('vue-devtools').uninstall()
+  }
+  ....
+})
+```
+
+
 
 ## An npm package base on https://github.com/vuejs/vue-devtools
 

--- a/index.js
+++ b/index.js
@@ -15,10 +15,10 @@ exports.install = () => {
 exports.uninstall = () => {
   if (process.type === 'renderer') {
     console.log(`Uninstalling Vue Devtools from ${__dirname}`)
-    return electron.remote.BrowserWindow.removeDevToolsExtension('devtron')
+    return electron.remote.BrowserWindow.removeDevToolsExtension('Vue.js devtools')
   } else if (process.type === 'browser') {
     console.log(`Uninstalling Vue Devtools from ${__dirname}`)
-    return electron.BrowserWindow.removeDevToolsExtension('devtron')
+    return electron.BrowserWindow.removeDevToolsExtension('Vue.js devtools')
   } else {
     throw new Error('Vue Devtools can only be uninstalled from an Electron process.')
   }


### PR DESCRIPTION
I dug into the package this morning to figure out why the uninstall function wasn't working. I found that the name of the tool in the index.js file did not match the manifest. I updated it and added instructions to the readme. 

Thanks for writing this tool.